### PR TITLE
Implement operator workflows and persistence

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/ilyakaznacheev/cleanenv v1.5.0/go.mod h1:a5aDzaJrLCQZsazHol1w8InnDcOX0OColm64SlIi6gk=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/segmentio/kafka-go v0.4.49/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3/go.mod h1:oVgVk4OWVDi43qWBEyGhXgYxt7+ED4iYNpTngSLX2Iw=

--- a/messages-service/TODO.md
+++ b/messages-service/TODO.md
@@ -1,0 +1,37 @@
+# Messages Service Gaps and Next Steps
+
+This repository contains only a thin slice of the desired functionality. Below is an audit of what is missing or needs correction to match the target behavior described in the project brief.
+
+## Config and bootstrapping
+- The config schema in `internal/config/config.go` expects sections `http_server`, `kafka`, `postgresql`, `retries`, and `org`, but `configs/messages-service.yaml` defines unrelated keys (`server`, `kafka.group_id`, `database`, etc.) and even has a malformed `org.file_path` line without a newline. The app will fail to start with the provided file and defaults are unlikely sufficient. Align the YAML structure with the Go struct or vice versa; add validation and defaults where necessary.
+- `logger.New` exists but is unused in `cmd/main.go`; logging is hard-coded to JSON. Decide on a single logger initialization path and honor the environment.
+- No graceful shutdown: the HTTP server and Kafka/Postgres clients are not closed on interrupt. Add signal handling and context cancellation.
+
+## Persistence
+- There is no database schema or migrations for the `mails` table and related columns (`classification`, `model_answer`, `failed_reason`, timestamps, `is_approved`, `assistant_response`, etc.). Introduce migrations and keep them in-repo.
+- Repository methods cover only a subset of required operations: missing list of processed messages, approval flag updates, and storing assistant responses. Add queries and indexes to support operator endpoints.
+- Retries rely on `attempts` but `CreateMail` always inserts `attempts=0` and never resets on success; ensure status/attempt consistency and consider optimistic locking to avoid lost updates.
+
+## HTTP API surface
+- Only `/process` and `/validate_processed_message` handlers are implemented. The operator endpoints described in the brief are absent: `getProcessedMessages`, `approveMessage`, and `add-assistant-response`. Add routing, DTOs, validation, and responses for these.
+- Responses are empty body with status codes; add structured JSON error/success payloads for observability and client ergonomics.
+- Request validation is minimal (checks only a few fields). Add stricter validation (email formats, timestamps, payload shape) and return meaningful errors.
+
+## Kafka integration
+- The service writes to Kafka but never consumes anything. If Kafka should be the entrypoint for LLM results or other events, add consumer support with configurable group IDs, timeouts, and retry/backoff. At minimum, ensure producer config honors `Producer.Timeout` and expose metrics.
+- `configs/messages-service.yaml` includes `group_id` and `consume_timeout_ms` that are unused; decide whether to support them or drop from config.
+
+## Domain logic gaps
+- `/validate_processed_message` performs only superficial validation of the LLM result. Implement structural validation (e.g., JSON schema) and content checks before accepting data.
+- Handling of hierarchy data (`configs/hierarchy.json`) is not implemented. Load and expose it in the service to drive routing/notifications/approvals as required by the project description.
+- Status lifecycle is incomplete: there is no transition to `processed=true`, no `is_approved` flag handling, and no dead-letter audit trail beyond a Kafka send. Ensure state is stored in Postgres consistently with retry outcomes.
+
+## Observability & testing
+- No metrics, tracing, or structured error wrapping; add at least request logging, correlation IDs, and Kafka/Postgres operation metrics.
+- No tests. Add unit tests for service logic (happy path, retries, DLQ), repository tests with a test DB, and handler tests.
+
+## Operational concerns
+- Add health/readiness endpoints for k8s/probes.
+- Document how to run the service locally (env vars, Docker compose for Kafka/Postgres, seeding hierarchy.json) and how to bootstrap the database.
+
+Addressing the above will bring the service in line with the intended pipeline and make it production-ready.

--- a/messages-service/configs/messages-service.yaml
+++ b/messages-service/configs/messages-service.yaml
@@ -1,26 +1,30 @@
-server:
-  name: messages-service
-  log_level: info
+env: local
+
+http_server:
+  address: "0.0.0.0:8080"
+  timeout: 5s
+  idle_timeout: 60s
 
 kafka:
   brokers:
     - "kafka:9092"
-  group_id: "email-processing-group"
-  input_topic: "incoming-emails"
-  output_topic: "processed-emails"
-  consume_timeout_ms: 5000
+  input_topic: "messages_to_process"
+  output_topic: "processed_messages"
+  dead_letter_topic: "messages_failed"
+  producer:
+    acks: "all"
+    timeout: 3s
 
+retries:
+  max_llm_attempts: 5
 
-
-database:
+postgresql:
   host: "postgres"
   port: 5432
   user: "postgres"
   password: "postgres"
   dbname: "emails"
   sslmode: "disable"
-  max_connections: 10
-  max_idle_connections: 5
 
 org:
   file_path: "./configs/hierarchy.json"

--- a/messages-service/internal/storage/repo.go
+++ b/messages-service/internal/storage/repo.go
@@ -20,10 +20,10 @@ func NewMessagesRepo(db *sql.DB) *Repo {
 
 func (r *Repo) CreateMail(ctx context.Context, m *messages.Mail) error {
 	const query = `
-		INSERT INTO mails 
-			(id, input, from_email, to_email, received_at, attempts, status)
-		VALUES ($1, $2, $3, $4, $5, $6, $7);
-	`
+INSERT INTO mails
+(id, input, from_email, to_email, received_at, attempts, status, processed, is_approved)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
+`
 
 	_, err := r.db.ExecContext(ctx, query,
 		m.ID,
@@ -33,33 +33,42 @@ func (r *Repo) CreateMail(ctx context.Context, m *messages.Mail) error {
 		m.ReceivedAt,
 		m.Attempts,
 		m.Status,
+		m.Processed,
+		m.IsApproved,
 	)
 	return err
 }
 
 func (r *Repo) GetMail(ctx context.Context, id string) (*messages.Mail, error) {
 	const query = `
-		SELECT 
-			id,
-			input,
-			from_email,
-			to_email,
-			received_at,
-			attempts,
-			status,
-			classification,
-			model_answer,
-			failed_reason
-		FROM mails
-		WHERE id = $1;
-	`
+SELECT
+id,
+input,
+from_email,
+to_email,
+received_at,
+attempts,
+status,
+classification,
+model_answer,
+failed_reason,
+assistant_response,
+processed,
+is_approved,
+updated_at
+FROM mails
+WHERE id = $1;
+`
 
 	row := r.db.QueryRowContext(ctx, query, id)
 
 	var mail messages.Mail
 	var modelAnswer json.RawMessage
+	var assistantResponse json.RawMessage
 	var classification sql.NullString
 	var failedReason sql.NullString
+	var processed sql.NullBool
+	var approved sql.NullBool
 
 	err := row.Scan(
 		&mail.ID,
@@ -72,6 +81,10 @@ func (r *Repo) GetMail(ctx context.Context, id string) (*messages.Mail, error) {
 		&classification,
 		&modelAnswer,
 		&failedReason,
+		&assistantResponse,
+		&processed,
+		&approved,
+		&mail.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -86,8 +99,17 @@ func (r *Repo) GetMail(ctx context.Context, id string) (*messages.Mail, error) {
 	if modelAnswer != nil {
 		mail.ModelAnswer = modelAnswer
 	}
+	if assistantResponse != nil {
+		mail.AssistantResp = assistantResponse
+	}
 	if failedReason.Valid {
 		mail.FailedReason = failedReason.String
+	}
+	if processed.Valid {
+		mail.Processed = processed.Bool
+	}
+	if approved.Valid {
+		mail.IsApproved = approved.Bool
 	}
 
 	return &mail, nil
@@ -118,13 +140,15 @@ func (r *Repo) IncrementAttempts(ctx context.Context, id string) error {
 
 func (r *Repo) SaveLLMResult(ctx context.Context, id string, classification string, modelAnswer json.RawMessage) error {
 	const query = `
-		UPDATE mails
-		SET classification = $2,
-		    model_answer = $3,
-		    status = 'processed',
-		    updated_at = NOW()
-		WHERE id = $1;
-	`
+UPDATE mails
+SET classification = $2,
+model_answer = $3,
+processed = TRUE,
+status = 'processed',
+attempts = 0,
+updated_at = NOW()
+WHERE id = $1;
+`
 
 	res, err := r.db.ExecContext(ctx, query,
 		id,
@@ -148,17 +172,108 @@ func (r *Repo) SaveLLMResult(ctx context.Context, id string, classification stri
 
 func (r *Repo) MarkAsFailed(ctx context.Context, id string, reason string) error {
 	const query = `
-		UPDATE mails
-		SET status = 'failed',
-		    failed_reason = $2,
-		    updated_at = NOW()
-		WHERE id = $1;
-	`
+UPDATE mails
+SET status = 'failed',
+failed_reason = $2,
+processed = FALSE,
+updated_at = NOW()
+WHERE id = $1;
+`
 
 	res, err := r.db.ExecContext(ctx, query,
 		id,
 		reason,
 	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("mail id %s not found", id)
+	}
+
+	return nil
+}
+
+func (r *Repo) ListProcessed(ctx context.Context) ([]messages.Mail, error) {
+	const query = `
+SELECT id, input, from_email, to_email, received_at, attempts, status, classification, model_answer, assistant_response, is_approved, updated_at
+FROM mails
+WHERE processed = TRUE
+ORDER BY updated_at DESC;
+`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var mails []messages.Mail
+	for rows.Next() {
+		var mail messages.Mail
+		if err := rows.Scan(
+			&mail.ID,
+			&mail.Input,
+			&mail.From,
+			&mail.To,
+			&mail.ReceivedAt,
+			&mail.Attempts,
+			&mail.Status,
+			&mail.Classification,
+			&mail.ModelAnswer,
+			&mail.AssistantResp,
+			&mail.IsApproved,
+			&mail.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		mail.Processed = true
+		mails = append(mails, mail)
+	}
+
+	return mails, nil
+}
+
+func (r *Repo) ApproveMail(ctx context.Context, id string) error {
+	const query = `
+UPDATE mails
+SET is_approved = TRUE,
+updated_at = NOW()
+WHERE id = $1;
+`
+
+	res, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return err
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("mail id %s not found", id)
+	}
+
+	return nil
+}
+
+func (r *Repo) SaveAssistantResponse(ctx context.Context, id string, response json.RawMessage, markProcessed bool) error {
+	const query = `
+UPDATE mails
+SET assistant_response = $2,
+processed = CASE WHEN $3 THEN TRUE ELSE processed END,
+status = CASE WHEN $3 THEN 'processed' ELSE status END,
+updated_at = NOW()
+WHERE id = $1;
+`
+
+	res, err := r.db.ExecContext(ctx, query, id, response, markProcessed)
 	if err != nil {
 		return err
 	}

--- a/messages-service/internal/transport/http/messages/handler.go
+++ b/messages-service/internal/transport/http/messages/handler.go
@@ -23,11 +23,14 @@ func New(svc *messages.Service, log *slog.Logger) *Handler {
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/process", h.handleProcess)
 	mux.HandleFunc("/validate_processed_message", h.handleValidateProcessedMessage)
+	mux.HandleFunc("/processed", h.handleGetProcessed)
+	mux.HandleFunc("/approve", h.handleApprove)
+	mux.HandleFunc("/add-assistant-response", h.handleAddAssistantResponse)
 }
 
 func (h *Handler) handleProcess(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
@@ -36,25 +39,25 @@ func (h *Handler) handleProcess(w http.ResponseWriter, r *http.Request) {
 	var dto messages.IncomingMessageDTO
 	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
 		h.log.Error("failed to decode /process body", slog.Any("error", err))
-		http.Error(w, "invalid json body", http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
 
-	if err := h.svc.ProcessIncomingMessage(r.Context(), dto); err != nil {
+	id, err := h.svc.ProcessIncomingMessage(r.Context(), dto)
+	if err != nil {
 		h.log.Error("failed to process incoming message",
 			slog.Any("error", err),
 		)
-		http.Error(w, "failed to process message", http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "failed to process message")
 		return
 	}
 
-	// На данном этапе нам достаточно статуса, без тела.
-	w.WriteHeader(http.StatusAccepted)
+	writeJSON(w, http.StatusAccepted, map[string]any{"status": "queued", "id": id})
 }
 
 func (h *Handler) handleValidateProcessedMessage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
@@ -63,7 +66,7 @@ func (h *Handler) handleValidateProcessedMessage(w http.ResponseWriter, r *http.
 	var dto messages.ValidateMessageDTO
 	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
 		h.log.Error("failed to decode /validate_processed_message body", slog.Any("error", err))
-		http.Error(w, "invalid json body", http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
 
@@ -72,9 +75,81 @@ func (h *Handler) handleValidateProcessedMessage(w http.ResponseWriter, r *http.
 			slog.Any("error", err),
 			slog.String("id", dto.ID),
 		)
-		http.Error(w, "failed to validate processed message", http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "failed to validate processed message")
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "accepted"})
+}
+
+func (h *Handler) handleGetProcessed(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	items, err := h.svc.GetProcessedMessages(r.Context())
+	if err != nil {
+		h.log.Error("failed to list processed messages", slog.Any("error", err))
+		writeError(w, http.StatusInternalServerError, "failed to list processed messages")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"messages": items})
+}
+
+func (h *Handler) handleApprove(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	defer r.Body.Close()
+	var dto messages.ApproveDTO
+	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
+		h.log.Error("failed to decode approve body", slog.Any("error", err))
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	if err := h.svc.ApproveMessage(r.Context(), dto); err != nil {
+		h.log.Error("failed to approve message", slog.Any("error", err), slog.String("id", dto.ID))
+		writeError(w, http.StatusInternalServerError, "failed to approve message")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "approved", "id": dto.ID})
+}
+
+func (h *Handler) handleAddAssistantResponse(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	defer r.Body.Close()
+	var dto messages.AssistantResponseDTO
+	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
+		h.log.Error("failed to decode add assistant response body", slog.Any("error", err))
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+
+	if err := h.svc.AddAssistantResponse(r.Context(), dto); err != nil {
+		h.log.Error("failed to save assistant response", slog.Any("error", err), slog.String("id", dto.ID))
+		writeError(w, http.StatusInternalServerError, "failed to save assistant response")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "saved", "id": dto.ID})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
 }

--- a/messages-service/migrations/001_init.sql
+++ b/messages-service/migrations/001_init.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS mails (
+    id UUID PRIMARY KEY,
+    input TEXT NOT NULL,
+    from_email TEXT NOT NULL,
+    to_email TEXT NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL,
+    classification TEXT,
+    model_answer JSONB,
+    assistant_response JSONB,
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
+    is_approved BOOLEAN NOT NULL DEFAULT FALSE,
+    failed_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mails_processed ON mails (processed);
+CREATE INDEX IF NOT EXISTS idx_mails_status ON mails (status);
+CREATE INDEX IF NOT EXISTS idx_mails_received_at ON mails (received_at);


### PR DESCRIPTION
## Summary
- align configuration with application schema, initialize logger/hierarchy, and add graceful shutdown
- add database migration and repository support for processed state, approvals, and assistant responses
- expose operator HTTP endpoints with structured JSON responses and stricter validation

## Testing
- go test ./... *(fails: module downloads blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929ba1c38008327991d32e79a9742db)