### PR TITLE
Add docker-compose for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# fuckatone
+# Mail processing stack
+
+This repository hosts two Go services and supporting infrastructure used to process incoming mails with an LLM.
+
+- **messages-service** — HTTP API for ingesting mails, persisting them to Postgres and publishing tasks to Kafka.
+- **llm-service** — HTTP worker that wraps the LLM call and returns JSON responses.
+- **docker-compose** — Local runtime for Postgres, Kafka/ZooKeeper and both services.
+
+## Running locally with Docker Compose
+1. Build and start the stack:
+   ```bash
+   docker compose up --build
+   ```
+2. Services expose the following ports on your host:
+   - messages-service: `http://localhost:8080`
+   - llm-service: `http://localhost:8081`
+   - Kafka broker: `localhost:9092`
+   - Postgres: `localhost:5432` (database `emails`, user/password `postgres`)
+
+Configuration defaults match the values in `messages-service/configs/messages-service.yaml`. Override the config path by setting `CONFIG_PATH` if needed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: emails
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d emails"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  zookeeper:
+    image: bitnami/zookeeper:3.9
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: bitnami/kafka:3.6
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"
+    ports:
+      - "9092:9092"
+
+  messages-service:
+    build:
+      context: .
+      dockerfile: messages-service/Dockerfile
+    depends_on:
+      kafka:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    environment:
+      CONFIG_PATH: /app/messages-service/configs/messages-service.yaml
+    ports:
+      - "8080:8080"
+
+  llm-service:
+    build:
+      context: ./llm-service
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8080"
+
+volumes:
+  postgres_data:

--- a/llm-service/Dockerfile
+++ b/llm-service/Dockerfile
@@ -1,0 +1,25 @@
+# Build stage
+FROM golang:1.25 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN cd llm-service && go mod download
+RUN cd llm-service && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/llm-service
+
+# Runtime stage
+FROM gcr.io/distroless/base-debian12
+
+WORKDIR /app/llm-service
+
+COPY --from=builder /app/bin/llm-service ./llm-service
+COPY llm-service/systemprompt.txt ./systemprompt.txt
+COPY llm-service/org.json ./org.json
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/llm-service/llm-service"]

--- a/messages-service/Dockerfile
+++ b/messages-service/Dockerfile
@@ -1,0 +1,23 @@
+# Build stage
+FROM golang:1.25 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY messages-service ./messages-service
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/messages-service ./messages-service/cmd
+
+# Runtime stage
+FROM gcr.io/distroless/base-debian12
+
+WORKDIR /app/messages-service
+
+COPY --from=builder /app/bin/messages-service ./messages-service
+COPY messages-service/configs ./configs
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/messages-service/messages-service"]


### PR DESCRIPTION
## Summary
- add a docker-compose stack with Postgres, Kafka/ZooKeeper, messages-service, and llm-service
- provide Dockerfiles to build runnable images for both Go services
- document how to start the local stack with docker compose

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692a5b1a477c8327a4e70219b800b5f4)